### PR TITLE
Add artifact bin after CI

### DIFF
--- a/.github/workflows/build_run.yml
+++ b/.github/workflows/build_run.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           name: om-binaries
           path: build/
+          retention-days: 1
   test_module_build:
     name: Test Module Build (Python${{ matrix.python-version }} ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -208,7 +209,6 @@ jobs:
     needs: [collate_coverage]
     steps:
     - name: Delete artifacts
-      if: github.event.action == 'delete_all_artifacts'
       uses: christian-korneck/delete-run-artifacts-action@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_run.yml
+++ b/.github/workflows/build_run.yml
@@ -201,3 +201,17 @@ jobs:
         with:
           env_vars: OS,PYTHON
           files: coverage.xml
+  clean_up:
+    name: Delete All Artifacts
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [collate_coverage]
+    steps:
+    - name: Delete artifacts
+      if: github.event.action == 'delete_all_artifacts'
+      uses: christian-korneck/delete-run-artifacts-action@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        parent_runid: ${{ github.event.client_payload.parent_runid  }}
+        parent_repo: ${{ github.event.client_payload.parent_repo }}

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -40,3 +40,17 @@ jobs:
         with:
           name: asv-results-${{ runner.os }}
           path: asv_benchmarks
+  clean_up:
+      name: Delete All Artifacts
+      runs-on: ubuntu-latest
+      if: ${{ always() }}
+      needs: [benchmark_diff]
+      steps:
+      - name: Delete artifacts
+        if: github.event.action == 'delete_all_artifacts'
+        uses: christian-korneck/delete-run-artifacts-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          parent_runid: ${{ github.event.client_payload.parent_runid  }}
+          parent_repo: ${{ github.event.client_payload.parent_repo }}

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           name: asv-results-${{ runner.os }}
           path: asv_benchmarks
+          retention-days: 1
   clean_up:
       name: Delete All Artifacts
       runs-on: ubuntu-latest
@@ -47,7 +48,6 @@ jobs:
       needs: [benchmark_diff]
       steps:
       - name: Delete artifacts
-        if: github.event.action == 'delete_all_artifacts'
         uses: christian-korneck/delete-run-artifacts-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/site_build_and_benchmarks_main.yml
+++ b/.github/workflows/site_build_and_benchmarks_main.yml
@@ -91,6 +91,7 @@ jobs:
       with:
         name: mktheapidocs
         path: docs/Reference
+        retention-days: 1
   build_pages:
     runs-on: ubuntu-latest
     name: Build Documentation Site
@@ -154,7 +155,6 @@ jobs:
       needs: [build_pages]
       steps:
       - name: Delete artifacts
-        if: github.event.action == 'delete_all_artifacts'
         uses: christian-korneck/delete-run-artifacts-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/site_build_and_benchmarks_main.yml
+++ b/.github/workflows/site_build_and_benchmarks_main.yml
@@ -147,3 +147,17 @@ jobs:
           branch: gh-pages
           force: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
+  clean_up:
+      name: Delete All Artifacts
+      runs-on: ubuntu-latest
+      if: ${{ always() }}
+      needs: [build_pages]
+      steps:
+      - name: Delete artifacts
+        if: github.event.action == 'delete_all_artifacts'
+        uses: christian-korneck/delete-run-artifacts-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          parent_runid: ${{ github.event.client_payload.parent_runid  }}
+          parent_repo: ${{ github.event.client_payload.parent_repo }}

--- a/tests/baseline/update_baseline.py
+++ b/tests/baseline/update_baseline.py
@@ -4,13 +4,14 @@ Update Regression Test Baseline Files
 """
 import glob
 import os.path
+import pickle
 import shutil
 import tempfile
-import power_balance.core as pbm_core
-import pickle
 
 import numpy as np
+
 import power_balance.calc.efficiencies as pbm_eff
+import power_balance.core as pbm_core
 import power_balance.profiles as pbm_prof
 
 BASELINE_DIR = os.path.dirname(__file__)


### PR DESCRIPTION
Unlike GitLab, GitHub keeps artifacts for 90 days! This means any CI which temporarily makes artifacts to share between jobs can very rapidly lead to the quota being reached for storage. This adds a step to delete all artifacts after completion.