### PR TITLE
Fix typo in structural parameter definition

### DIFF
--- a/power_balance/models/Magnets.mo
+++ b/power_balance/models/Magnets.mo
@@ -240,7 +240,7 @@ and may or may not make physical sense. It is up to the user to verify that all 
     //
     // ==================== Defining Structural Parameters =======================
     parameter Boolean useSuperconModel = true "STRUCTURAL_PARAMETER";
-    parameter Boolean isPSUeffValue = false "STRUCTURAL PARAMETER";
+    parameter Boolean isPSUeffValue = false "STRUCTURAL_PARAMETER";
     parameter Boolean isMagnetTFSuperconCoil = false "STRUCTURAL_PARAMETER";
     parameter Boolean isMagnetTFSuperconFeeder = false "STRUCTURAL_PARAMETER";
     parameter Boolean isMagnetPF1SuperconCoil = false "STRUCTURAL_PARAMETER";


### PR DESCRIPTION
The missing underscore meant the parameter on line 243 wasn't detected as a structural parameter and thus did not change.