### PR TITLE
Use v2.1 of credentials action

### DIFF
--- a/.github/workflows/site_build_and_benchmarks_main.yml
+++ b/.github/workflows/site_build_and_benchmarks_main.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install OpenModelica libraries
       run: apt -y install omlib-modelica-3.2.3 omlib-modelicaservices-3.2.3 omlib-complex-3.2.3
     - name: Configure Git credentials
-      uses: OleksiyRudenko/gha-git-credentials@v2
+      uses: OleksiyRudenko/gha-git-credentials@v2.1
       with:
         email: action@github.com
         token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
Updates the "OleksiyRudenko/gha-git-credentials" action to v2.1 hopefully fixing benchmarks